### PR TITLE
Use official gray-matter package with engines feature

### DIFF
--- a/lib/site.coffee
+++ b/lib/site.coffee
@@ -7,17 +7,22 @@ matter = require 'gray-matter'
 
 sitePath = path.join __dirname, 'gpa-centex.org'
 
+engines =
+  yaml:
+    parse: yaml.parse.bind(yaml)
+    stringify: yaml.dump.bind(yaml)
+
 module.exports =
   loadGreyhound: (greyhound, callback) ->
     file = "#{sitePath}/_greyhounds/#{greyhound}.md"
     fs.readFile file, 'utf8', (err, data) ->
       if err
         return callback null, null
-      info = matter data, parser: yaml.parse
+      info = matter data, engines: engines
       callback info.data, info.content
 
   dumpGreyhound: (greyhound, info, bio, callback) ->
     file = "#{sitePath}/_greyhounds/#{greyhound}.md"
-    data = matter.stringify bio, info, dumper: yaml.dump
+    data = matter.stringify bio, info, engines: engines
     fs.writeFile file, data, (err) ->
       callback err

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coffeescript": "^1.12.6",
     "dateformat": "^2.0.0",
     "github-api": "^3.0.0",
-    "gray-matter": "github:zachwhaley/gray-matter",
+    "gray-matter": "^3.0.3",
     "hubot": "^2.19.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-help": "^0.2.0",


### PR DESCRIPTION
gray-matter 3.0.0 introduced a feature that allows us to override the
parsers and stringifyers for yaml front matter, which we could only do
with the parser before.